### PR TITLE
Upgrade OGL to 0.4.2

### DIFF
--- a/bootstrap_ogl.sh
+++ b/bootstrap_ogl.sh
@@ -73,39 +73,39 @@ else
   echo "   ⚠ Router 'albert-testbed' not found, skipping provider creation"
 fi
 
-# Check if router ID 3 exists and needs a provider
-ROUTER_3_EXISTS=$(echo $ROUTERS | jq -r '.data[] | select(.id == 3) | .id')
-if [ -n "$ROUTER_3_EXISTS" ]; then
-  ROUTER_3_PROVIDERS=$(echo $ROUTERS | jq -r '.data[] | select(.id == 3) | .providers')
+# Check if ministral-3b router exists and needs a provider
+MINISTRAL_ROUTER_ID=$(echo $ROUTERS | jq -r '.data[] | select(.name == "mistralai/Ministral-3-3B-Instruct-2512") | .id')
+if [ -n "$MINISTRAL_ROUTER_ID" ] && [ "$MINISTRAL_ROUTER_ID" != "null" ]; then
+  MINISTRAL_PROVIDERS=$(echo $ROUTERS | jq -r ".data[] | select(.id == $MINISTRAL_ROUTER_ID) | .providers")
 
-  if [ "$ROUTER_3_PROVIDERS" = "0" ]; then
-    echo "   Creating provider for mistralai/Mistral-Small-3.2-24B-Instruct-2506 (Router ID 3)..."
-    PROVIDER_3=$(curl -s -X POST "${BASE_URL}/v1/admin/providers" \
+  if [ "$MINISTRAL_PROVIDERS" = "0" ]; then
+    echo "   Creating provider for mistralai/Ministral-3-3B-Instruct-2512 (Router ID ${MINISTRAL_ROUTER_ID})..."
+    PROVIDER_MINISTRAL=$(curl -s -X POST "${BASE_URL}/v1/admin/providers" \
       -H "Content-Type: application/json" \
       -H "Authorization: Bearer ${ADMIN_API_KEY}" \
       -d '{
-        "router": 3,
+        "router": '${MINISTRAL_ROUTER_ID}',
         "type": "vllm",
         "url": "http://opengatellm-stack-router-service/",
         "key": "changeme",
-        "model_name": "mistralai/Mistral-Small-3.2-24B-Instruct-2506",
+        "model_name": "mistralai/Ministral-3-3B-Instruct-2512",
         "timeout": 300,
         "model_carbon_footprint_zone": "WOR",
-        "model_carbon_footprint_total_params": 0,
-        "model_carbon_footprint_active_params": 0
+        "model_carbon_footprint_total_params": 3000000000,
+        "model_carbon_footprint_active_params": 3000000000
       }')
 
-    PROVIDER_3_ID=$(echo $PROVIDER_3 | jq -r '.id')
-    if [ "$PROVIDER_3_ID" != "null" ]; then
-      echo "   ✓ Provider created for Mistral-Small with ID: ${PROVIDER_3_ID}"
+    PROVIDER_MINISTRAL_ID=$(echo $PROVIDER_MINISTRAL | jq -r '.id')
+    if [ "$PROVIDER_MINISTRAL_ID" != "null" ]; then
+      echo "   ✓ Provider created for Ministral-3B with ID: ${PROVIDER_MINISTRAL_ID}"
     else
-      echo "   ✗ Failed to create provider. Response: $PROVIDER_3"
+      echo "   ✗ Failed to create provider. Response: $PROVIDER_MINISTRAL"
     fi
   else
-    echo "   ✓ Provider already exists for Mistral-Small (Router ID 3)"
+    echo "   ✓ Provider already exists for Ministral-3B (Router ID ${MINISTRAL_ROUTER_ID})"
   fi
 else
-  echo "   ⚠ Router ID 3 not found, skipping provider creation"
+  echo "   ⚠ Router 'mistralai/Ministral-3-3B-Instruct-2512' not found, skipping provider creation"
 fi
 
 echo ""

--- a/charts/opengatellm-core/Chart.yaml
+++ b/charts/opengatellm-core/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: opengatellm-core
 description: A Helm chart for OpenGateLLM
 type: application
-version: 0.3.3
-appVersion: "0.3.6"
+version: 0.4.0
+appVersion: "0.4.2"
 dependencies:
   - name: redis-ha
     alias: redis

--- a/charts/opengatellm-core/values.yaml
+++ b/charts/opengatellm-core/values.yaml
@@ -12,7 +12,7 @@ api:
     labels: {}
   image:
     repository: ghcr.io/etalab-ia/opengatellm/api
-    tag: "0.3.6"
+    tag: "0.4.2"
     pullPolicy: IfNotPresent
 
   replicas: 1

--- a/charts/opengatellm-stack/Chart.lock
+++ b/charts/opengatellm-stack/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: opengatellm-core
   repository: file://../opengatellm-core
-  version: 0.2.0
+  version: 0.3.3
 - name: vllm-stack
   repository: https://vllm-project.github.io/production-stack
   version: 0.1.8
-digest: sha256:5d3eea4e05c303b67707ab3c401ddc50b60a682f67dd0ade655efc6a81d18313
-generated: "2026-01-22T10:34:54.581797+01:00"
+digest: sha256:584fe7bc8404cb797b5bff8786999b7b9d01f96d044a15b48cd8ff37f2249b1d
+generated: "2026-04-14T12:18:35.607458+02:00"

--- a/charts/opengatellm-stack/Chart.yaml
+++ b/charts/opengatellm-stack/Chart.yaml
@@ -2,12 +2,12 @@ apiVersion: v2
 name: opengatellm-stack
 description: A Helm chart for OpenGateLLM Stack
 type: application
-version: 0.8.3
+version: 0.8.4
 appVersion: "0.3.6"
 
 dependencies:
   - name: opengatellm-core
-    version: "0.3.3"
+    version: "0.4.0"
     repository: "file://../opengatellm-core"
     condition: opengatellm-core.enabled
   - name: vllm-stack

--- a/charts/opengatellm-stack/values.yaml
+++ b/charts/opengatellm-stack/values.yaml
@@ -16,8 +16,15 @@ opengatellm-core:
     replicas: 1
     image:
       repository: ghcr.io/etalab-ia/opengatellm/api
-      tag: 0.3.6
+      tag: 0.4.2
       pullPolicy: IfNotPresent
+    resources:
+      requests:
+        cpu: "200m"
+        memory: "1Gi"
+      limits:
+        cpu: "1"
+        memory: "3Gi"
     service:
       type: ClusterIP
       port: 8000
@@ -33,14 +40,14 @@ opengatellm-core:
             url: "http://albert-testbed.etalab.gouv.fr:8000"
             key: "changeme"
 
-# Example config for a model deployed with the vllm of this stack
-#      - name: mistralai/Mistral-Small-3.2-24B-Instruct-2506
-#        type: text-generation
-#        providers:
-#          - type: vllm
-#            model_name: "mistralai/Mistral-Small-3.2-24B-Instruct-2506"
-#            url: "http://opengatellm-router-service/"
-#            key: "changeme"
+      # Example config for a model deployed with the vllm of this stack
+      - name: mistralai/Ministral-3-3B-Instruct-2512
+        type: text-generation
+        providers:
+          - type: vllm
+            model_name: "mistralai/Ministral-3-3B-Instruct-2512"
+            url: "http://opengatellm-stack-router-service/"
+            key: "changeme"
 
 
       # If embeddings are deployed through TEI, use this version :
@@ -68,17 +75,33 @@ opengatellm-core:
           url: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/api
           echo: False
           pool_size: 5
+          max_overflow: 10
+          pool_pre_ping: true
           connect_args:
             server_settings:
-              statement_timeout: "120s"
+              application_name: "OpenGateLLM production"
+              statement_timeout: "60s"
             command_timeout: 60
         redis:
           url: redis://:${REDIS_PASSWORD}@${REDIS_HOST}:${REDIS_PORT}
+          max_connections: 200
+          socket_connect_timeout: 5
+          retry_on_timeout: true
+          health_check_interval: 30
+          decode_responses: false
+          socket_keepalive: true
 
         elasticsearch:
+          index_name: opengatellm
+          index_language: english
+          number_of_shards: 24
+          number_of_replicas: 1
+          request_timeout: 120
+          retry_on_timeout: true
           hosts: "http://{{ .Release.Name }}-elasticsearch-es-http:9200"
 
       settings:
+        swagger_version: "{{ .Values.api.image.tag }}"
         log_level: INFO
         vector_store_model: "BAAI/bge-m3"
 
@@ -153,25 +176,25 @@ vllm-stack:
     enableEngine: true
     vllmApiKey: "changeme"
     modelSpec:
-      - name: "mistral-small"
+      - name: "ministral-3b"
         repository: vllm/vllm-openai
         tag: v0.11.0
         imagePullPolicy: IfNotPresent
-        modelURL: mistralai/Mistral-Small-3.2-24B-Instruct-2506
+        modelURL: mistralai/Ministral-3-3B-Instruct-2512
 
         replicaCount: 1
-        requestCPU: 20
-        requestMemory: "200G"
+        requestCPU: 2
+        requestMemory: "8G"
         requestGPU: 1
-        limitCPU: "22"
-        limitMemory: "230G"
+        limitCPU: "6"
+        limitMemory: "20G"
 
-        pvcStorage: "230Gi"
+        pvcStorage: "20Gi"
         storageClass: sbs-default
         pvcAccessMode:
           - ReadWriteOnce
 
-        shmSize: "32Gi"
+        shmSize: "2Gi"
 
         vllmConfig:
           tensorParallelSize: 1
@@ -186,6 +209,8 @@ vllm-stack:
             - "--tool-call-parser"
             - "mistral"
             - "--enable-auto-tool-choice"
+            - "--max-model-len"
+            - "128000"
 
         hf_token:
           secretName: "huggingface-token"


### PR DESCRIPTION
- Upgrade OGL to 0.4.2
- Switch default vLLM model to Ministral-3-3B and resource limits to fit in a smaller GPU (L24 24Go)
- increase OGL memory limit 1Gi→3Gi to fit the 4 Gunicorn workers
- add ogl new config params
- make swagger_version dynamic
- Bump chart versions